### PR TITLE
Add experiment framework, web enrichment, and GitHub publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,8 @@ DATABASE_URL=
 # OpenRouter API
 OPENROUTER_API_KEY=your_openrouter_api_key_here
 
+# Exa AI API (for web research enrichment)
+EXA_API_KEY=your_exa_api_key_here
+
 # Optional: Environment
 NODE_ENV=development

--- a/README.md
+++ b/README.md
@@ -164,7 +164,13 @@ pnpm dev run:experiment -e 002 -u <market-url>
 ## Todos
 
 Publishing
-- Add command flag to run:experiment and also a new command that publishes a summary of the prediction results and market to a gist gh gist create prediction-[predictionid].md include a link to betteraiengine https://github.com/better-labs/betteraiengine and experiment number and all inputs used.
+- Add command option to run:experiment and run:experiments-batch that publishes a summary of the prediction results and market to a gist gh gist create prediction-[predictionid].md include a link to betteraiengine https://github.com/better-labs/betteraiengine and experiment number and all inputs used.
+
+put the bulk of the code for the new option functionality under /services/prediction-publish.ts
+
+start the markdown with an overview of the AI prediction delta and any key fields from the prediction object. Then add a section that recaps the market overview
+
+towards the end, include the original raw request, response, model id, and any valuable metadata such as when the job was ran, number of tokens, etc.
 
 
 Benchmarking
@@ -179,7 +185,9 @@ https://docs.exa.ai/reference/get-contents
 https://docs.exa.ai/websets/overview
 https://websets.exa.ai/websets?_gl=1*zer51j*_gcl_au*MTI4MzA0ODI2Ni4xNzU3MDIxNTE4*_ga*NTE3MDI5MDQwLjE3NTcwMjE1MTg.*_ga_CPMTFL65Z3*czE3NTk3MDgxMzMkbzUkZzEkdDE3NTk3MDgxMzMkajYwJGwwJGgxMTM0NzM5MDM0
 - enrich each prediction with data from x/twitter GROK search first
-- modify prediction result json to include to separate discrete prediction child elements outcomeReasoning (the reasoning for the outcome) and confidenceReasoning (the reason for the outcome)
+
+- post update to twitter
+
 - run the prediction across multiple top models from config/models.ts, including open source and chinese models
 - Add custom user supplied context. Seek out experts in a given field to apply their knowledge to the prediction
 - Optimize the system prompt. Pipe one AI's response to another AI

--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ pnpm dev run:experiment -e 002 -u <market-url>
 
 ### Future Experiments list:
 
+- add optional field to published doc: modify published data output to highlight research more clearly. 
+
 - enrich each prediction with data from x/twitter GROK search first
 
 - post update to twitter - "[model] predicts .." eg https://x.com/Kalshi/status/1975612799192866873

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-BetterAI-Engine is a headless backend system for generating AI-powered predictions on Polymarket markets. It ingests market data from the Polymarket Gamma API, stores structured data and raw API payloads in Postgres, and runs a prediction pipeline via LangChain and OpenRouter. The system is operated through CLI commands and scheduled batch jobs.
+BetterAI Engine is a headless backend system for generating AI-powered predictions on Polymarket markets. It ingests market data from the Polymarket Gamma API, stores structured data and raw API payloads in Postgres, and runs a prediction pipeline via LangChain and OpenRouter. The system is operated through CLI commands and scheduled batch jobs.
+
+BetterAI Engine is part of the evolving BetterAI platform. Please see the other ongoing work here: https://github.com/better-labs
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,8 @@ pnpm dev run:experiment -e 002 -u <market-url>
 
 ## Todos
 
+Publishing
+- Add command flag to run:experiment and also a new command that publishes a summary of the prediction results and market to a gist gh gist create prediction-[predictionid].md include a link to betteraiengine https://github.com/better-labs/betteraiengine and experiment number and all inputs used.
 
 
 Benchmarking

--- a/README.md
+++ b/README.md
@@ -170,8 +170,11 @@ pnpm dev run:experiment -e 002 -u <market-url>
 - Pull predictioncheck design and "open" definition from betteraiv1.
 
 ### Future Experiments list:
-- enrich each prediction with data from Exa
-Adding basic data lookup for the market from Exa.ai using datasets
+- I want to create a new experiment 004 that adds a data collection step prior to invoking the model prediction. I want to enrich the prediction with data from Exa.ai Step 1: trigger a request to exa.ai for the best possible dataset or datasets or web infomration related to the prediction market.be sure to limit this to 50k tokens or the equivalent number of characters to avoid overloading the context window for the AI model
+Step 2: will be to invoke the normal model prediction, but pass all the data from exa AI as added to the contextPrompt. 
+
+Exa AI has their web search APIs, websets api and more. Do a deep search to recommend which API(s) or multiple are best for this research. think deeply
+Example references:
 https://docs.exa.ai/reference/research/create-a-task
 https://docs.exa.ai/reference/get-contents
 https://docs.exa.ai/websets/overview

--- a/README.md
+++ b/README.md
@@ -165,23 +165,11 @@ pnpm dev run:experiment -e 002 -u <market-url>
 
 ## Todos
 
-### Benchmarking
-- Add a Prediction Check batch job that pulls the latest Market information for all markets currently listed as open.
-- Pull predictioncheck design and "open" definition from betteraiv1.
-
 ### Future Experiments list:
-- I want to create a new experiment 004 that adds a data collection step prior to invoking the model prediction. I want to enrich the prediction with data from Exa.ai Step 1: trigger a request to exa.ai for the best possible dataset or datasets or web infomration related to the prediction market.be sure to limit this to 50k tokens or the equivalent number of characters to avoid overloading the context window for the AI model
-Step 2: will be to invoke the normal model prediction, but pass all the data from exa AI as added to the contextPrompt. 
 
-Exa AI has their web search APIs, websets api and more. Do a deep search to recommend which API(s) or multiple are best for this research. think deeply
-Example references:
-https://docs.exa.ai/reference/research/create-a-task
-https://docs.exa.ai/reference/get-contents
-https://docs.exa.ai/websets/overview
-https://websets.exa.ai/websets?_gl=1*zer51j*_gcl_au*MTI4MzA0ODI2Ni4xNzU3MDIxNTE4*_ga*NTE3MDI5MDQwLjE3NTcwMjE1MTg.*_ga_CPMTFL65Z3*czE3NTk3MDgxMzMkbzUkZzEkdDE3NTk3MDgxMzMkajYwJGwwJGgxMTM0NzM5MDM0
 - enrich each prediction with data from x/twitter GROK search first
 
-- post update to twitter - "[model] predicts .."
+- post update to twitter - "[model] predicts .." eg https://x.com/Kalshi/status/1975612799192866873
 
 - consider whether to generate a twitter overview image for the prediction?
 
@@ -190,3 +178,6 @@ https://websets.exa.ai/websets?_gl=1*zer51j*_gcl_au*MTI4MzA0ODI2Ni4xNzU3MDIxNTE4
 - Optimize the system prompt. Pipe one AI's response to another AI
 
 
+### Benchmarking
+- Add a Prediction Check batch job that pulls the latest Market information for all markets currently listed as open.
+- Pull predictioncheck design and "open" definition from betteraiv1.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ pnpm dev run:experiment -e 002 -u <market-url>
 - run the prediction across multiple top models from config/models.ts, including open source and chinese models
 - Add custom user supplied context. Seek out experts in a given field to apply their knowledge to the prediction
 - Optimize the system prompt. Pipe one AI's response to another AI
+- test adding websets enrichment
 
 
 ### Benchmarking

--- a/README.md
+++ b/README.md
@@ -165,21 +165,11 @@ pnpm dev run:experiment -e 002 -u <market-url>
 
 ## Todos
 
-Publishing
-- Add command option to run:experiment and run:experiments-batch that publishes a summary of the prediction results and market to a gist gh gist create prediction-[predictionid].md include a link to betteraiengine https://github.com/better-labs/betteraiengine and experiment number and all inputs used.
-
-put the bulk of the code for the new option functionality under /services/prediction-publish.ts
-
-start the markdown with an overview of the AI prediction delta and any key fields from the prediction object. Then add a section that recaps the market overview
-
-towards the end, include the original raw request, response, model id, and any valuable metadata such as when the job was ran, number of tokens, etc.
-
-
-Benchmarking
+### Benchmarking
 - Add a Prediction Check batch job that pulls the latest Market information for all markets currently listed as open.
 - Pull predictioncheck design and "open" definition from betteraiv1.
 
-Future Experiments list:
+### Future Experiments list:
 - enrich each prediction with data from Exa
 Adding basic data lookup for the market from Exa.ai using datasets
 https://docs.exa.ai/reference/research/create-a-task
@@ -188,7 +178,9 @@ https://docs.exa.ai/websets/overview
 https://websets.exa.ai/websets?_gl=1*zer51j*_gcl_au*MTI4MzA0ODI2Ni4xNzU3MDIxNTE4*_ga*NTE3MDI5MDQwLjE3NTcwMjE1MTg.*_ga_CPMTFL65Z3*czE3NTk3MDgxMzMkbzUkZzEkdDE3NTk3MDgxMzMkajYwJGwwJGgxMTM0NzM5MDM0
 - enrich each prediction with data from x/twitter GROK search first
 
-- post update to twitter
+- post update to twitter - "[model] predicts .."
+
+- consider whether to generate a twitter overview image for the prediction?
 
 - run the prediction across multiple top models from config/models.ts, including open source and chinese models
 - Add custom user supplied context. Seek out experts in a given field to apply their knowledge to the prediction

--- a/db/schema.ts
+++ b/db/schema.ts
@@ -98,6 +98,7 @@ export const predictions = pgTable('predictions', {
   id: uuid('id').defaultRandom().primaryKey(),
   jobId: uuid('job_id').references(() => predictionJobs.id).notNull(),
   marketId: text('market_id').references(() => markets.marketId),
+  experimentId: text('experiment_id').notNull().default('unknown'),
 
   // Prediction output
   prediction: jsonb('prediction').notNull(), // Structured prediction output

--- a/drizzle/0003_high_the_call.sql
+++ b/drizzle/0003_high_the_call.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "predictions" ADD COLUMN "experiment_id" text DEFAULT 'unknown' NOT NULL;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,612 @@
+{
+  "id": "9b5e3fc0-0b1a-4724-b02c-c7d8be10c76c",
+  "prevId": "c7f6738c-f3b9-45b0-99d4-5d8f7bbd1e40",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "events_event_id_unique": {
+          "name": "events_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        },
+        "events_slug_unique": {
+          "name": "events_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.markets": {
+      "name": "markets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "closed": {
+          "name": "closed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "volume": {
+          "name": "volume",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "liquidity": {
+          "name": "liquidity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "markets_event_id_events_event_id_fk": {
+          "name": "markets_event_id_events_event_id_fk",
+          "tableFrom": "markets",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "event_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "markets_market_id_unique": {
+          "name": "markets_market_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "market_id"
+          ]
+        },
+        "markets_slug_unique": {
+          "name": "markets_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.prediction_jobs": {
+      "name": "prediction_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "prediction_jobs_market_id_markets_market_id_fk": {
+          "name": "prediction_jobs_market_id_markets_market_id_fk",
+          "tableFrom": "prediction_jobs",
+          "tableTo": "markets",
+          "columnsFrom": [
+            "market_id"
+          ],
+          "columnsTo": [
+            "market_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "prediction_jobs_event_id_events_event_id_fk": {
+          "name": "prediction_jobs_event_id_events_event_id_fk",
+          "tableFrom": "prediction_jobs",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "event_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.predictions": {
+      "name": "predictions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'unknown'"
+        },
+        "prediction": {
+          "name": "prediction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_request": {
+          "name": "raw_request",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_response": {
+          "name": "raw_response",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prediction_delta": {
+          "name": "prediction_delta",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "predictions_job_id_prediction_jobs_id_fk": {
+          "name": "predictions_job_id_prediction_jobs_id_fk",
+          "tableFrom": "predictions",
+          "tableTo": "prediction_jobs",
+          "columnsFrom": [
+            "job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "predictions_market_id_markets_market_id_fk": {
+          "name": "predictions_market_id_markets_market_id_fk",
+          "tableFrom": "predictions",
+          "tableTo": "markets",
+          "columnsFrom": [
+            "market_id"
+          ],
+          "columnsTo": [
+            "market_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_events": {
+      "name": "raw_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "(data->>'id')::text",
+            "type": "stored"
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(data->>'slug')::text",
+            "type": "stored"
+          }
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "raw_events_event_id_unique": {
+          "name": "raw_events_event_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.raw_markets": {
+      "name": "raw_markets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "market_id": {
+          "name": "market_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "generated": {
+            "as": "(data->>'id')::text",
+            "type": "stored"
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(data->>'slug')::text",
+            "type": "stored"
+          }
+        },
+        "condition_id": {
+          "name": "condition_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(data->>'conditionId')::text",
+            "type": "stored"
+          }
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "raw_markets_market_id_unique": {
+          "name": "raw_markets_market_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "market_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1759839980890,
       "tag": "0002_rich_nuke",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1759868806788,
+      "tag": "0003_high_the_call",
+      "breakpoints": true
     }
   ]
 }

--- a/experiments/config.ts
+++ b/experiments/config.ts
@@ -48,6 +48,19 @@ export const experimentRegistry: ExperimentRegistry = {
     updatedAt: '2025-10-07',
     loader: () => import('./exp003/main.js'),
   },
+
+  '004': {
+    id: '004',
+    name: 'Exa AI Web Research Enrichment',
+    description: 'Enriches predictions with real-time web research data from Exa AI. Uses Search + Contents APIs to gather relevant sources, then passes enriched context to Claude Sonnet 4.5 for structured prediction with source citations.',
+    version: '1.0.0',
+    author: 'BetterAI Team',
+    enabled: true,
+    tags: ['claude', 'sonnet-4.5', 'exa-ai', 'web-research', 'enrichment', 'structured-output', 'zod', 'delta'],
+    createdAt: '2025-10-07',
+    updatedAt: '2025-10-07',
+    loader: () => import('./exp004/main.js'),
+  },
 };
 
 /**

--- a/experiments/config.ts
+++ b/experiments/config.ts
@@ -35,6 +35,19 @@ export const experimentRegistry: ExperimentRegistry = {
     updatedAt: '2025-10-07',
     loader: () => import('./exp002/main.js'),
   },
+
+  '003': {
+    id: '003',
+    name: 'Claude Sonnet 4.5 Separated Reasoning',
+    description: 'Builds on exp002 with separated reasoning fields: outcomeReasoning (why YES/NO/UNCERTAIN) and confidenceReasoning (why specific confidence level).',
+    version: '1.0.0',
+    author: 'BetterAI Team',
+    enabled: true,
+    tags: ['claude', 'sonnet-4.5', 'structured-output', 'zod', 'delta', 'separated-reasoning'],
+    createdAt: '2025-10-07',
+    updatedAt: '2025-10-07',
+    loader: () => import('./exp003/main.js'),
+  },
 };
 
 /**

--- a/experiments/exp001/main.ts
+++ b/experiments/exp001/main.ts
@@ -122,8 +122,10 @@ export async function run(market: PolymarketMarket): Promise<ExperimentResult> {
     // Save prediction to database
     await savePrediction({
       marketId: market.id,
+      experimentId: '001',
       prediction: predictionData,
       rawRequest: {
+        experimentId: '001',
         messages: messages.map(msg => ({
           role: msg._getType(),
           content: msg.content,

--- a/experiments/exp002/main.ts
+++ b/experiments/exp002/main.ts
@@ -201,8 +201,10 @@ export async function run(market: PolymarketMarket): Promise<ExperimentResult> {
     // Save prediction to database
     await savePrediction({
       marketId: market.id,
+      experimentId: '002',
       prediction: predictionData,
       rawRequest: {
+        experimentId: '002',
         messages: messages.map(msg => ({
           role: msg._getType(),
           content: msg.content,

--- a/experiments/exp003/README.md
+++ b/experiments/exp003/README.md
@@ -1,0 +1,49 @@
+# Experiment 003: Separated Reasoning Fields
+
+## Changes vs Experiment 002
+
+This experiment builds on [exp002](../exp002/main.ts) with the following modifications:
+
+### Prediction Schema Changes
+
+The `prediction` object now includes **two separate reasoning fields** instead of a single combined reasoning field:
+
+#### Before (exp002):
+```typescript
+prediction: {
+  outcome: z.enum(['YES', 'NO', 'UNCERTAIN']),
+  confidence: z.number().min(0).max(100),
+  probability: z.number().min(0).max(100),
+  reasoning: z.string().min(10).describe('Detailed explanation for the prediction'),
+}
+```
+
+#### After (exp003):
+```typescript
+prediction: {
+  outcome: z.enum(['YES', 'NO', 'UNCERTAIN']),
+  outcomeReasoning: z.string().min(10).describe('Detailed reasoning for the predicted outcome'),
+  confidence: z.number().min(0).max(100),
+  confidenceReasoning: z.string().min(10).describe('Detailed reasoning for the confidence level'),
+  probability: z.number().min(0).max(100),
+}
+```
+
+### Key Differences
+
+1. **`outcomeReasoning`**: Dedicated field explaining why the model chose YES, NO, or UNCERTAIN
+2. **`confidenceReasoning`**: Dedicated field explaining why the model assigned a specific confidence level (0-100)
+
+This separation allows for:
+- More structured and explicit reasoning
+- Better analysis of how the model arrives at its outcome vs. its confidence
+- Improved transparency in the prediction process
+- Potential for separate evaluation of outcome logic vs. confidence calibration
+
+### All Other Features Remain the Same
+
+- Claude Sonnet 4.5 via OpenRouter
+- Structured JSON output with Zod validation
+- Prediction delta calculation
+- Comprehensive logging
+- Database persistence

--- a/experiments/exp003/main.ts
+++ b/experiments/exp003/main.ts
@@ -1,0 +1,249 @@
+import { logger } from '../../utils/logger.js';
+import { ChatOpenAI } from '@langchain/openai';
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { z } from 'zod';
+import { PolymarketMarket } from '../../services/polymarket.js';
+import { savePrediction, saveFailedPrediction } from '../../services/prediction-storage.js';
+import {
+  calculatePredictionDelta,
+  formatOutcomePrices,
+} from '../../utils/market-utils.js';
+
+export interface ExperimentResult {
+  success: boolean;
+  data?: any;
+  error?: string;
+}
+
+/**
+ * Zod schema for structured prediction output with separated reasoning
+ */
+const PredictionSchema = z.object({
+  marketId: z.string().describe('Polymarket market identifier'),
+  question: z.string().describe('Market question being analyzed'),
+  prediction: z.object({
+    outcome: z.enum(['YES', 'NO', 'UNCERTAIN']).describe('Predicted outcome'),
+    outcomeReasoning: z.string().min(10).describe('Detailed reasoning for the predicted outcome'),
+    confidence: z.number().min(0).max(100).describe('Confidence level in prediction (0-100)'),
+    confidenceReasoning: z.string().min(10).describe('Detailed reasoning for the confidence level'),
+    probability: z.number().min(0).max(100).describe('Estimated probability of YES outcome (0-100)'),
+  }),
+  keyFactors: z.array(z.string()).min(1).describe('Key factors influencing the prediction'),
+  dataQuality: z.enum(['HIGH', 'MEDIUM', 'LOW']).describe('Quality of available data for analysis'),
+  lastUpdated: z.string().datetime().describe('ISO timestamp of prediction'),
+});
+
+export type PredictionOutput = z.infer<typeof PredictionSchema>;
+
+/**
+ * Build the system prompt for market prediction
+ */
+function buildSystemPrompt(): string {
+  return `You are an expert prediction analyst for Polymarket markets. Your role is to analyze market questions and provide structured, data-driven predictions.
+
+Guidelines:
+- Analyze the question carefully and consider all available information
+- Provide a clear outcome prediction: YES, NO, or UNCERTAIN
+- Provide separate, detailed reasoning for your outcome prediction
+- Assign a confidence level (0-100) based on the strength of available evidence
+- Provide separate, detailed reasoning for your confidence level
+- Estimate a probability (0-100) for the YES outcome
+- Identify key factors that influence the outcome
+- Assess the quality of available data
+
+Be objective, balanced, and transparent about uncertainty. Focus on verifiable information over speculation.`;
+}
+
+/**
+ * Build the context prompt from market data
+ */
+function buildContextPrompt(market: PolymarketMarket): string {
+  const marketInfo = `
+Market Question: ${market.question}
+
+Description: ${market.description || 'No description available'}
+
+Market Details:
+- Market ID: ${market.id}
+- Condition ID: ${market.conditionId}
+- Active: ${market.active ? 'Yes' : 'No'}
+- Closed: ${market.closed ? 'Yes' : 'No'}
+- Current Volume: ${market.volume || 'N/A'}
+- Current Liquidity: ${market.liquidity || 'N/A'}
+- Current Outcome Prices: ${formatOutcomePrices(market.outcomePrices)}
+
+Please analyze this market and provide a structured prediction following this EXACT JSON format:
+{
+  "marketId": "${market.id}",
+  "question": "${market.question}",
+  "prediction": {
+    "outcome": "YES" | "NO" | "UNCERTAIN",
+    "outcomeReasoning": "<detailed reasoning for the predicted outcome>",
+    "confidence": <number 0-100>,
+    "confidenceReasoning": "<detailed reasoning for the confidence level>",
+    "probability": <number 0-100>
+  },
+  "keyFactors": ["<factor 1>", "<factor 2>", ...],
+  "dataQuality": "HIGH" | "MEDIUM" | "LOW",
+  "lastUpdated": "<ISO 8601 timestamp>"
+}
+
+IMPORTANT:
+- Respond ONLY with valid JSON
+- Do not include markdown code blocks or any other text
+- The probability field should be your estimated probability of the YES outcome (0-100)
+- Provide separate reasoning for both the outcome and confidence level
+- Ensure all required fields are included`;
+
+  return marketInfo;
+}
+
+/**
+ * Experiment 003: Claude Sonnet 4.5 with separated reasoning fields
+ * Entry point for running this experiment
+ */
+export async function run(market: PolymarketMarket): Promise<ExperimentResult> {
+  try {
+    // Initialize LangChain with OpenRouter (Claude Sonnet 4.5)
+    const model = new ChatOpenAI({
+      model: 'anthropic/claude-sonnet-4.5',
+      temperature: 0.7,
+      apiKey: process.env.OPENROUTER_API_KEY,
+      configuration: {
+        baseURL: 'https://openrouter.ai/api/v1',
+        defaultHeaders: {
+          'HTTP-Referer': 'https://betterai.tools',
+          'X-Title': 'BetterAI Engine',
+        },
+      },
+    });
+
+    // Build prompts
+    const systemPrompt = buildSystemPrompt();
+    const contextPrompt = buildContextPrompt(market);
+
+    // Prepare messages
+    const messages = [
+      new SystemMessage(systemPrompt),
+      new HumanMessage(contextPrompt),
+    ];
+
+    // Invoke the model
+    const response = await model.invoke(messages);
+
+    // Parse the response - extract JSON and validate with Zod
+    let predictionData: PredictionOutput;
+    try {
+      let content = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+
+      // Remove markdown code blocks if present
+      const jsonMatch = content.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+      if (jsonMatch) {
+        content = jsonMatch[1].trim();
+      }
+
+      // Try to parse as JSON
+      const parsed = JSON.parse(content);
+
+      // Validate with Zod schema
+      predictionData = PredictionSchema.parse(parsed);
+    } catch (parseError) {
+      const parseErrorMessage = parseError instanceof Error ? parseError.message : String(parseError);
+      logger.error(
+        {
+          experimentId: '003',
+          marketId: market.id,
+          error: parseErrorMessage,
+          responseContent: response.content,
+        },
+        'Failed to parse or validate prediction response'
+      );
+      throw new Error(`Failed to parse prediction: ${parseErrorMessage}`);
+    }
+
+    logger.info(
+      {
+        experimentId: '003',
+        marketId: market.id,
+        outcome: predictionData.prediction.outcome,
+        confidence: predictionData.prediction.confidence,
+        probability: predictionData.prediction.probability,
+      },
+      'Structured prediction generated and validated'
+    );
+
+    // Calculate prediction delta
+    const deltaResult = calculatePredictionDelta(
+      market.outcomePrices,
+      predictionData.prediction.probability
+    );
+
+    let predictionDelta: number | undefined;
+    if (deltaResult.success && deltaResult.value !== undefined) {
+      predictionDelta = deltaResult.value;
+      logger.info(
+        {
+          experimentId: '003',
+          marketId: market.id,
+          delta: predictionDelta,
+          marketPrice: market.outcomePrices,
+          predictedProbability: predictionData.prediction.probability,
+        },
+        'Prediction delta calculated'
+      );
+    } else {
+      logger.warn(
+        {
+          experimentId: '003',
+          marketId: market.id,
+          error: deltaResult.error,
+        },
+        'Failed to calculate prediction delta - will save prediction without delta'
+      );
+    }
+
+    // Save prediction to database
+    await savePrediction({
+      marketId: market.id,
+      prediction: predictionData,
+      rawRequest: {
+        messages: messages.map(msg => ({
+          role: msg._getType(),
+          content: msg.content,
+        })),
+        model: 'anthropic/claude-sonnet-4.5',
+        temperature: 0.7,
+      },
+      rawResponse: response,
+      model: 'anthropic/claude-sonnet-4.5',
+      predictionDelta,
+      promptTokens: response.response_metadata?.tokenUsage?.promptTokens,
+      completionTokens: response.response_metadata?.tokenUsage?.completionTokens,
+    });
+
+    return {
+      success: true,
+      data: {
+        marketId: market.id,
+        prediction: predictionData,
+        predictionDelta,
+        model: 'anthropic/claude-sonnet-4.5',
+      },
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    logger.error(
+      { experimentId: '003', marketId: market.id, error: errorMessage },
+      'Experiment 003 failed'
+    );
+
+    // Save failed prediction job
+    await saveFailedPrediction(market.id, errorMessage);
+
+    return {
+      success: false,
+      error: errorMessage,
+    };
+  }
+}

--- a/experiments/exp003/main.ts
+++ b/experiments/exp003/main.ts
@@ -205,8 +205,10 @@ export async function run(market: PolymarketMarket): Promise<ExperimentResult> {
     // Save prediction to database
     await savePrediction({
       marketId: market.id,
+      experimentId: '003',
       prediction: predictionData,
       rawRequest: {
+        experimentId: '003',
         messages: messages.map(msg => ({
           role: msg._getType(),
           content: msg.content,

--- a/experiments/exp004/README.md
+++ b/experiments/exp004/README.md
@@ -49,7 +49,7 @@ After deep research into Exa AI's APIs, I recommend **Search + Contents** over a
 
 - **Research API**: Unavailable (500 errors) and likely overkill for single predictions
 - **Answer API**: Too narrow - gives one answer instead of rich research context
-- **Websets**: Pre-curated collections lack the dynamism needed for diverse markets
+- **Websets**: Optimized for building monitored or curated web collections with webhooks—powerful, but heavier than needed for on-demand, single-market research
 
 ## Key Features
 

--- a/experiments/exp004/README.md
+++ b/experiments/exp004/README.md
@@ -1,0 +1,163 @@
+# Experiment 004: Exa AI Web Research Enrichment
+
+## Overview
+
+Experiment 004 enhances prediction accuracy by enriching the AI model's context with real-time web research data from Exa AI before generating predictions. This experiment builds on the structured output approach from exp003 while adding a critical data collection step.
+
+## Architecture
+
+### Two-Step Pipeline
+
+```
+1. Data Collection (Exa AI)
+   ↓
+2. Enriched Prediction (Claude Sonnet 4.5)
+```
+
+### Step 1: Web Research Collection
+
+Uses Exa AI's **Search API + Contents API** to gather relevant information:
+
+- **Input**: Market question (e.g., "Will Georgia Tech win the 2026 College Football National Championship?")
+- **Process**:
+  - Exa's neural search finds 8 semantically relevant web sources
+  - Contents API extracts summaries, highlights, and text from each source
+  - Results are aggregated and formatted into structured research context
+- **Output**: Formatted research context with multiple sources, summaries, and key highlights
+- **Token Limit**: Capped at ~200k characters (~50k tokens) to avoid context window overflow
+
+### Step 2: Enriched Prediction
+
+Uses Claude Sonnet 4.5 with the enriched context:
+
+- **Input**: Original market data + Web research context
+- **Process**: AI model analyzes both Polymarket data and web research to generate prediction
+- **Output**: Structured JSON prediction with reasoning that cites research sources
+
+## Why This API Combination?
+
+After deep research into Exa AI's APIs, I recommend **Search + Contents** over alternatives:
+
+### ✅ Recommended: Search API + Contents API
+
+- **Neural search** finds semantically similar content (better than keyword matching)
+- **Contents API** provides clean, parsed text with summaries and highlights
+- **Flexible**: Can control text length, number of highlights, and summary generation
+- **Efficient**: Aggregates data in one round-trip with character limits
+
+### ❌ Not Recommended
+
+- **Research API**: Unavailable (500 errors) and likely overkill for single predictions
+- **Answer API**: Too narrow - gives one answer instead of rich research context
+- **Websets**: Pre-curated collections lack the dynamism needed for diverse markets
+
+## Key Features
+
+1. **Graceful Degradation**: If Exa API fails, continues with prediction (without enrichment)
+2. **Token Management**: Automatically truncates content to stay within ~50k token limit
+3. **Source Attribution**: AI reasoning can reference specific web sources
+4. **Metadata Tracking**: Stores enrichment metadata (# sources, characters, truncation status)
+5. **Structured Output**: Same Zod schema as exp003 with separated reasoning fields
+
+## Configuration
+
+### Environment Variables
+
+Add to `.env.local`:
+
+```bash
+EXA_API_KEY=your_exa_api_key_here
+```
+
+### Exa Research Parameters
+
+Defined in `services/exa-research.ts`:
+
+- `numResults`: 8 (number of web sources to fetch)
+- `type`: 'neural' (semantic search vs keyword)
+- `useAutoprompt`: true (let Exa optimize the search query)
+- `contents.text.maxCharacters`: 2000 per source
+- `contents.highlights.numSentences`: 3 sentences per highlight
+- `contents.summary`: true (generate summaries)
+
+## Data Flow
+
+```typescript
+Market Question
+  ↓
+Exa AI Search (neural, 8 results)
+  ↓
+Exa AI Contents (summaries, highlights, text)
+  ↓
+Format Research Context (markdown)
+  ↓
+Truncate to 200k chars (~50k tokens)
+  ↓
+Combine with Market Data
+  ↓
+Claude Sonnet 4.5 Prediction
+  ↓
+Structured JSON Output + Delta
+  ↓
+Save to Database with Enrichment Metadata
+```
+
+## Example Usage
+
+```bash
+pnpm dev run:experiment -e 004 -u https://polymarket.com/event/college-football-champion-2026-684/will-georgia-tech-win-the-2026-college-football-national-championship
+```
+
+## Prediction Schema
+
+Same as exp003 with added enrichment metadata:
+
+```typescript
+{
+  marketId: string,
+  question: string,
+  prediction: {
+    outcome: "YES" | "NO" | "UNCERTAIN",
+    outcomeReasoning: string,
+    confidence: number,  // 0-100
+    confidenceReasoning: string,
+    probability: number  // 0-100
+  },
+  keyFactors: string[],
+  dataQuality: "HIGH" | "MEDIUM" | "LOW",
+  lastUpdated: string,  // ISO timestamp
+  enrichmentMetadata: {
+    exaResearchSuccess: boolean,
+    numSources: number,
+    totalCharacters: number,
+    truncated: boolean
+  }
+}
+```
+
+## Benefits Over Previous Experiments
+
+### vs exp001 (Baseline GPT-4)
+- ✅ Real-time web research data
+- ✅ Structured output with Zod validation
+- ✅ Better model (Claude Sonnet 4.5)
+
+### vs exp002/003 (Structured Claude)
+- ✅ **Enriched context** with current, real-world information
+- ✅ AI can cite specific sources in reasoning
+- ✅ Higher data quality assessment
+- ✅ More informed confidence levels
+
+## Cost Considerations
+
+- **Exa AI**: ~$0.001-0.01 per search depending on contents fetched
+- **Claude Sonnet 4.5**: Higher token usage due to enriched context (~10-30k tokens)
+- **Trade-off**: Higher cost for potentially more accurate predictions
+
+## Future Enhancements
+
+- Add date filtering for time-sensitive markets
+- Cache research results to reduce API calls
+- A/B test predictions with/without enrichment
+- Add Exa findSimilar for related market discovery
+- Implement source quality scoring

--- a/experiments/exp004/main.ts
+++ b/experiments/exp004/main.ts
@@ -270,6 +270,7 @@ export async function run(market: PolymarketMarket): Promise<ExperimentResult> {
     // Save prediction to database with enrichment metadata
     await savePrediction({
       marketId: market.id,
+      experimentId: '004',
       prediction: {
         ...predictionData,
         enrichmentMetadata: {
@@ -280,6 +281,7 @@ export async function run(market: PolymarketMarket): Promise<ExperimentResult> {
         },
       },
       rawRequest: {
+        experimentId: '004',
         messages: messages.map(msg => ({
           role: msg._getType(),
           content: msg.content,

--- a/experiments/exp004/main.ts
+++ b/experiments/exp004/main.ts
@@ -1,0 +1,328 @@
+import { logger } from '../../utils/logger.js';
+import { ChatOpenAI } from '@langchain/openai';
+import { HumanMessage, SystemMessage } from '@langchain/core/messages';
+import { z } from 'zod';
+import { PolymarketMarket } from '../../services/polymarket.js';
+import { savePrediction, saveFailedPrediction } from '../../services/prediction-storage.js';
+import {
+  calculatePredictionDelta,
+  formatOutcomePrices,
+} from '../../utils/market-utils.js';
+import {
+  performExaResearch,
+  formatExaResearchContext,
+} from '../../services/exa-research.js';
+
+export interface ExperimentResult {
+  success: boolean;
+  data?: any;
+  error?: string;
+}
+
+/**
+ * Zod schema for structured prediction output with separated reasoning
+ */
+const PredictionSchema = z.object({
+  marketId: z.string().describe('Polymarket market identifier'),
+  question: z.string().describe('Market question being analyzed'),
+  prediction: z.object({
+    outcome: z.enum(['YES', 'NO', 'UNCERTAIN']).describe('Predicted outcome'),
+    outcomeReasoning: z.string().min(10).describe('Detailed reasoning for the predicted outcome'),
+    confidence: z.number().min(0).max(100).describe('Confidence level in prediction (0-100)'),
+    confidenceReasoning: z.string().min(10).describe('Detailed reasoning for the confidence level'),
+    probability: z.number().min(0).max(100).describe('Estimated probability of YES outcome (0-100)'),
+  }),
+  keyFactors: z.array(z.string()).min(1).describe('Key factors influencing the prediction'),
+  dataQuality: z.enum(['HIGH', 'MEDIUM', 'LOW']).describe('Quality of available data for analysis'),
+  lastUpdated: z.string().datetime().describe('ISO timestamp of prediction'),
+});
+
+export type PredictionOutput = z.infer<typeof PredictionSchema>;
+
+/**
+ * Build the system prompt for market prediction
+ */
+function buildSystemPrompt(): string {
+  return `You are an expert prediction analyst for Polymarket markets. Your role is to analyze market questions and provide structured, data-driven predictions.
+
+You have access to comprehensive web research data gathered specifically for this prediction. Use this research to inform your analysis.
+
+Guidelines:
+- Carefully analyze the market question and all available information including web research
+- Synthesize insights from multiple sources in the research data
+- Provide a clear outcome prediction: YES, NO, or UNCERTAIN
+- Provide separate, detailed reasoning for your outcome prediction
+- Assign a confidence level (0-100) based on the strength of available evidence
+- Provide separate, detailed reasoning for your confidence level
+- Estimate a probability (0-100) for the YES outcome
+- Identify key factors that influence the outcome
+- Assess the quality of available data (including web research)
+- Reference specific sources from the research when relevant
+
+Be objective, balanced, and transparent about uncertainty. Focus on verifiable information over speculation. The web research provides current, real-world context that should heavily inform your prediction.`;
+}
+
+/**
+ * Build the context prompt from market data and web research
+ */
+function buildContextPrompt(market: PolymarketMarket, researchContext: string): string {
+  const marketInfo = `
+# Market Information
+
+## Market Question
+${market.question}
+
+## Description
+${market.description || 'No description available'}
+
+## Market Details
+- Market ID: ${market.id}
+- Condition ID: ${market.conditionId}
+- Active: ${market.active ? 'Yes' : 'No'}
+- Closed: ${market.closed ? 'Yes' : 'No'}
+- Current Volume: ${market.volume || 'N/A'}
+- Current Liquidity: ${market.liquidity || 'N/A'}
+- Current Outcome Prices: ${formatOutcomePrices(market.outcomePrices)}
+
+---
+
+${researchContext}
+
+---
+
+# Task
+
+Please analyze this market using ALL the information above (both market details and web research) and provide a structured prediction following this EXACT JSON format:
+
+{
+  "marketId": "${market.id}",
+  "question": "${market.question}",
+  "prediction": {
+    "outcome": "YES" | "NO" | "UNCERTAIN",
+    "outcomeReasoning": "<detailed reasoning for the predicted outcome, citing specific research sources>",
+    "confidence": <number 0-100>,
+    "confidenceReasoning": "<detailed reasoning for the confidence level, referencing data quality and source reliability>",
+    "probability": <number 0-100>
+  },
+  "keyFactors": ["<factor 1>", "<factor 2>", ...],
+  "dataQuality": "HIGH" | "MEDIUM" | "LOW",
+  "lastUpdated": "<ISO 8601 timestamp>"
+}
+
+IMPORTANT:
+- Respond ONLY with valid JSON
+- Do not include markdown code blocks or any other text
+- The probability field should be your estimated probability of the YES outcome (0-100)
+- Provide separate reasoning for both the outcome and confidence level
+- Reference specific research sources in your reasoning
+- Consider the recency and reliability of sources when assessing data quality
+- Ensure all required fields are included`;
+
+  return marketInfo;
+}
+
+/**
+ * Experiment 004: Exa AI Web Research Enrichment
+ * Enriches predictions with real-time web research data from Exa AI
+ */
+export async function run(market: PolymarketMarket): Promise<ExperimentResult> {
+  try {
+    logger.info({ experimentId: '004', marketId: market.id }, 'Starting experiment 004 with Exa AI enrichment');
+
+    // Step 1: Perform web research using Exa AI
+    logger.info({ experimentId: '004', marketId: market.id, question: market.question }, 'Fetching web research data from Exa AI');
+
+    const researchResult = await performExaResearch({
+      query: market.question,
+      numResults: 8,
+      useAutoprompt: true,
+      type: 'neural',
+      contents: {
+        text: { maxCharacters: 2000 },
+        highlights: { numSentences: 3, highlightsPerUrl: 3 },
+        summary: true,
+      },
+    });
+
+    if (!researchResult.success) {
+      logger.error(
+        { experimentId: '004', marketId: market.id, error: researchResult.error },
+        'Exa AI research failed - proceeding without enrichment'
+      );
+      // Continue with empty research context rather than failing completely
+    }
+
+    const researchContext = researchResult.success && researchResult.data
+      ? formatExaResearchContext(researchResult.data.contents)
+      : 'No additional research data available due to API error.';
+
+    logger.info(
+      {
+        experimentId: '004',
+        marketId: market.id,
+        researchSuccess: researchResult.success,
+        numSources: researchResult.data?.contents.length || 0,
+        totalCharacters: researchResult.data?.totalCharacters || 0,
+      },
+      'Web research data prepared'
+    );
+
+    // Step 2: Initialize LangChain with OpenRouter (Claude Sonnet 4.5)
+    const model = new ChatOpenAI({
+      model: 'anthropic/claude-sonnet-4.5',
+      temperature: 0.7,
+      apiKey: process.env.OPENROUTER_API_KEY,
+      configuration: {
+        baseURL: 'https://openrouter.ai/api/v1',
+        defaultHeaders: {
+          'HTTP-Referer': 'https://betterai.tools',
+          'X-Title': 'BetterAI Engine',
+        },
+      },
+    });
+
+    // Build prompts with enriched research context
+    const systemPrompt = buildSystemPrompt();
+    const contextPrompt = buildContextPrompt(market, researchContext);
+
+    // Prepare messages
+    const messages = [
+      new SystemMessage(systemPrompt),
+      new HumanMessage(contextPrompt),
+    ];
+
+    logger.info({ experimentId: '004', marketId: market.id }, 'Invoking AI model with enriched context');
+
+    // Invoke the model
+    const response = await model.invoke(messages);
+
+    // Parse the response - extract JSON and validate with Zod
+    let predictionData: PredictionOutput;
+    try {
+      let content = typeof response.content === 'string' ? response.content : JSON.stringify(response.content);
+
+      // Remove markdown code blocks if present
+      const jsonMatch = content.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
+      if (jsonMatch) {
+        content = jsonMatch[1].trim();
+      }
+
+      // Try to parse as JSON
+      const parsed = JSON.parse(content);
+
+      // Validate with Zod schema
+      predictionData = PredictionSchema.parse(parsed);
+    } catch (parseError) {
+      const parseErrorMessage = parseError instanceof Error ? parseError.message : String(parseError);
+      logger.error(
+        {
+          experimentId: '004',
+          marketId: market.id,
+          error: parseErrorMessage,
+          responseContent: response.content,
+        },
+        'Failed to parse or validate prediction response'
+      );
+      throw new Error(`Failed to parse prediction: ${parseErrorMessage}`);
+    }
+
+    logger.info(
+      {
+        experimentId: '004',
+        marketId: market.id,
+        outcome: predictionData.prediction.outcome,
+        confidence: predictionData.prediction.confidence,
+        probability: predictionData.prediction.probability,
+      },
+      'Structured prediction generated and validated'
+    );
+
+    // Calculate prediction delta
+    const deltaResult = calculatePredictionDelta(
+      market.outcomePrices,
+      predictionData.prediction.probability
+    );
+
+    let predictionDelta: number | undefined;
+    if (deltaResult.success && deltaResult.value !== undefined) {
+      predictionDelta = deltaResult.value;
+      logger.info(
+        {
+          experimentId: '004',
+          marketId: market.id,
+          delta: predictionDelta,
+          marketPrice: market.outcomePrices,
+          predictedProbability: predictionData.prediction.probability,
+        },
+        'Prediction delta calculated'
+      );
+    } else {
+      logger.warn(
+        {
+          experimentId: '004',
+          marketId: market.id,
+          error: deltaResult.error,
+        },
+        'Failed to calculate prediction delta - will save prediction without delta'
+      );
+    }
+
+    // Save prediction to database with enrichment metadata
+    await savePrediction({
+      marketId: market.id,
+      prediction: {
+        ...predictionData,
+        enrichmentMetadata: {
+          exaResearchSuccess: researchResult.success,
+          numSources: researchResult.data?.contents.length || 0,
+          totalCharacters: researchResult.data?.totalCharacters || 0,
+          truncated: researchResult.data?.truncated || false,
+        },
+      },
+      rawRequest: {
+        messages: messages.map(msg => ({
+          role: msg._getType(),
+          content: msg.content,
+        })),
+        model: 'anthropic/claude-sonnet-4.5',
+        temperature: 0.7,
+        enrichment: 'exa-ai-research',
+      },
+      rawResponse: response,
+      model: 'anthropic/claude-sonnet-4.5',
+      predictionDelta,
+      promptTokens: response.response_metadata?.tokenUsage?.promptTokens,
+      completionTokens: response.response_metadata?.tokenUsage?.completionTokens,
+    });
+
+    return {
+      success: true,
+      data: {
+        marketId: market.id,
+        prediction: predictionData,
+        predictionDelta,
+        model: 'anthropic/claude-sonnet-4.5',
+        enrichment: {
+          source: 'exa-ai',
+          numSources: researchResult.data?.contents.length || 0,
+          totalCharacters: researchResult.data?.totalCharacters || 0,
+        },
+      },
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+
+    logger.error(
+      { experimentId: '004', marketId: market.id, error: errorMessage },
+      'Experiment 004 failed'
+    );
+
+    // Save failed prediction job
+    await saveFailedPrediction(market.id, errorMessage);
+
+    return {
+      success: false,
+      error: errorMessage,
+    };
+  }
+}

--- a/services/exa-research.ts
+++ b/services/exa-research.ts
@@ -1,0 +1,234 @@
+import { logger } from '../utils/logger.js';
+
+/**
+ * Exa AI Research Service
+ * Provides web research capabilities using Exa AI's Search and Contents APIs
+ */
+
+export interface ExaSearchResult {
+  id: string;
+  url: string;
+  title: string;
+  publishedDate?: string;
+  author?: string;
+  score?: number;
+}
+
+export interface ExaContentResult {
+  url: string;
+  title: string;
+  text?: string;
+  summary?: string;
+  highlights?: string[];
+  publishedDate?: string;
+  author?: string;
+}
+
+export interface ExaResearchOptions {
+  query: string;
+  numResults?: number;
+  useAutoprompt?: boolean;
+  type?: 'neural' | 'keyword';
+  contents?: {
+    text?: boolean | { maxCharacters?: number };
+    highlights?: boolean | { numSentences?: number; highlightsPerUrl?: number };
+    summary?: boolean | { query?: string };
+  };
+}
+
+export interface ExaResearchResult {
+  success: boolean;
+  data?: {
+    searchResults: ExaSearchResult[];
+    contents: ExaContentResult[];
+    totalCharacters: number;
+    truncated: boolean;
+  };
+  error?: string;
+}
+
+const EXA_API_BASE = 'https://api.exa.ai';
+const MAX_CHARACTERS = 200000; // ~50k tokens limit
+
+/**
+ * Perform web research using Exa AI's Search + Contents APIs
+ */
+export async function performExaResearch(options: ExaResearchOptions): Promise<ExaResearchResult> {
+  const apiKey = process.env.EXA_API_KEY;
+
+  if (!apiKey) {
+    logger.error('EXA_API_KEY not found in environment variables');
+    return {
+      success: false,
+      error: 'EXA_API_KEY not configured',
+    };
+  }
+
+  try {
+    const {
+      query,
+      numResults = 8,
+      useAutoprompt = true,
+      type = 'neural',
+      contents = {
+        text: { maxCharacters: 2000 },
+        highlights: { numSentences: 3, highlightsPerUrl: 3 },
+        summary: true,
+      },
+    } = options;
+
+    logger.info({ query, numResults, type }, 'Starting Exa AI research');
+
+    // Build the search request with contents
+    const searchPayload = {
+      query,
+      numResults,
+      useAutoprompt,
+      type,
+      contents,
+    };
+
+    // Call Exa Search API with contents parameter
+    const response = await fetch(`${EXA_API_BASE}/search`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+      body: JSON.stringify(searchPayload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      logger.error(
+        { status: response.status, error: errorText },
+        'Exa AI search request failed'
+      );
+      return {
+        success: false,
+        error: `Exa AI API error: ${response.status} - ${errorText}`,
+      };
+    }
+
+    const data = await response.json();
+
+    // Extract search results
+    const searchResults: ExaSearchResult[] = (data.results || []).map((result: any) => ({
+      id: result.id,
+      url: result.url,
+      title: result.title,
+      publishedDate: result.publishedDate,
+      author: result.author,
+      score: result.score,
+    }));
+
+    // Extract contents
+    const contents: ExaContentResult[] = (data.results || []).map((result: any) => ({
+      url: result.url,
+      title: result.title,
+      text: result.text,
+      summary: result.summary,
+      highlights: result.highlights,
+      publishedDate: result.publishedDate,
+      author: result.author,
+    }));
+
+    // Calculate total characters and truncate if needed
+    let totalCharacters = 0;
+    let truncated = false;
+    const truncatedContents: ExaContentResult[] = [];
+
+    for (const content of contents) {
+      const contentText = [
+        content.title,
+        content.summary,
+        content.text,
+        ...(content.highlights || []),
+      ]
+        .filter(Boolean)
+        .join(' ');
+
+      const contentLength = contentText.length;
+
+      if (totalCharacters + contentLength <= MAX_CHARACTERS) {
+        truncatedContents.push(content);
+        totalCharacters += contentLength;
+      } else {
+        truncated = true;
+        logger.warn(
+          { totalCharacters, maxCharacters: MAX_CHARACTERS },
+          'Content truncated to stay within token limits'
+        );
+        break;
+      }
+    }
+
+    logger.info(
+      {
+        numResults: searchResults.length,
+        numContents: truncatedContents.length,
+        totalCharacters,
+        truncated,
+      },
+      'Exa AI research completed'
+    );
+
+    return {
+      success: true,
+      data: {
+        searchResults,
+        contents: truncatedContents,
+        totalCharacters,
+        truncated,
+      },
+    };
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.error({ error: errorMessage }, 'Exa AI research failed');
+
+    return {
+      success: false,
+      error: errorMessage,
+    };
+  }
+}
+
+/**
+ * Format Exa research results into a readable context string for AI models
+ */
+export function formatExaResearchContext(contents: ExaContentResult[]): string {
+  if (contents.length === 0) {
+    return 'No additional research data available.';
+  }
+
+  const sections = contents.map((content, index) => {
+    const parts: string[] = [];
+
+    parts.push(`## Source ${index + 1}: ${content.title}`);
+    parts.push(`URL: ${content.url}`);
+
+    if (content.publishedDate) {
+      parts.push(`Published: ${content.publishedDate}`);
+    }
+
+    if (content.author) {
+      parts.push(`Author: ${content.author}`);
+    }
+
+    if (content.summary) {
+      parts.push(`\n### Summary\n${content.summary}`);
+    }
+
+    if (content.highlights && content.highlights.length > 0) {
+      parts.push(`\n### Key Highlights\n${content.highlights.map(h => `- ${h}`).join('\n')}`);
+    }
+
+    if (content.text) {
+      parts.push(`\n### Content\n${content.text}`);
+    }
+
+    return parts.join('\n');
+  });
+
+  return `# Web Research Data\n\nThe following information was gathered from web research to provide context for this prediction:\n\n${sections.join('\n\n---\n\n')}`;
+}

--- a/services/exa-research.ts
+++ b/services/exa-research.ts
@@ -47,8 +47,94 @@ export interface ExaResearchResult {
   error?: string;
 }
 
+interface ExaSearchApiContent {
+  text?: string;
+  summary?: string;
+  highlights?: unknown;
+  publishedDate?: string;
+  author?: string;
+}
+
+interface ExaSearchApiResult {
+  id: string;
+  url: string;
+  title: string;
+  publishedDate?: string;
+  author?: string;
+  score?: number;
+  text?: unknown;
+  summary?: unknown;
+  highlights?: unknown;
+  contents?: ExaSearchApiContent;
+  content?: ExaSearchApiContent;
+}
+
+interface ExaSearchResponse {
+  results?: ExaSearchApiResult[];
+}
+
 const EXA_API_BASE = 'https://api.exa.ai';
 const MAX_CHARACTERS = 200000; // ~50k tokens limit
+const STRING_FALLBACK_KEYS = ['text', 'summary', 'content', 'snippet', 'value'];
+
+function extractString(value: unknown): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    const joined = value
+      .map(item => (typeof item === 'string' ? item : extractString(item)))
+      .filter((item): item is string => Boolean(item))
+      .join(' ')
+      .trim();
+    return joined.length > 0 ? joined : undefined;
+  }
+
+  if (typeof value === 'object') {
+    for (const key of STRING_FALLBACK_KEYS) {
+      const candidate = (value as Record<string, unknown>)[key];
+      if (typeof candidate === 'string' && candidate.trim().length > 0) {
+        return candidate;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function extractHighlights(highlights: unknown): string[] | undefined {
+  if (!highlights) {
+    return undefined;
+  }
+
+  if (typeof highlights === 'string') {
+    return [highlights];
+  }
+
+  if (!Array.isArray(highlights)) {
+    const single = extractString(highlights);
+    return single ? [single] : undefined;
+  }
+
+  const normalized = highlights
+    .map(item => {
+      if (typeof item === 'string') {
+        return item;
+      }
+      if (item && typeof item === 'object') {
+        return extractString(item);
+      }
+      return undefined;
+    })
+    .filter((item): item is string => Boolean(item && item.trim().length));
+
+  return normalized.length > 0 ? normalized : undefined;
+}
 
 /**
  * Perform web research using Exa AI's Search + Contents APIs
@@ -70,7 +156,7 @@ export async function performExaResearch(options: ExaResearchOptions): Promise<E
       numResults = 8,
       useAutoprompt = true,
       type = 'neural',
-      contents = {
+      contents: contentsConfig = {
         text: { maxCharacters: 2000 },
         highlights: { numSentences: 3, highlightsPerUrl: 3 },
         summary: true,
@@ -85,7 +171,7 @@ export async function performExaResearch(options: ExaResearchOptions): Promise<E
       numResults,
       useAutoprompt,
       type,
-      contents,
+      contents: contentsConfig,
     };
 
     // Call Exa Search API with contents parameter
@@ -110,10 +196,11 @@ export async function performExaResearch(options: ExaResearchOptions): Promise<E
       };
     }
 
-    const data = await response.json();
+    const data = (await response.json()) as ExaSearchResponse;
+    const results = data.results ?? [];
 
     // Extract search results
-    const searchResults: ExaSearchResult[] = (data.results || []).map((result: any) => ({
+    const searchResults: ExaSearchResult[] = results.map(result => ({
       id: result.id,
       url: result.url,
       title: result.title,
@@ -123,32 +210,34 @@ export async function performExaResearch(options: ExaResearchOptions): Promise<E
     }));
 
     // Extract contents
-    const contents: ExaContentResult[] = (data.results || []).map((result: any) => ({
-      url: result.url,
-      title: result.title,
-      text: result.text,
-      summary: result.summary,
-      highlights: result.highlights,
-      publishedDate: result.publishedDate,
-      author: result.author,
-    }));
+    const contentResults: ExaContentResult[] = results.map(result => {
+      const resultContents = result.contents ?? result.content ?? {};
+
+      return {
+        url: result.url,
+        title: result.title || 'Untitled Source',
+        text: extractString(result.text ?? resultContents.text),
+        summary: extractString(result.summary ?? resultContents.summary),
+        highlights: extractHighlights(result.highlights ?? resultContents.highlights),
+        publishedDate: result.publishedDate ?? resultContents.publishedDate,
+        author: result.author ?? resultContents.author,
+      };
+    });
 
     // Calculate total characters and truncate if needed
     let totalCharacters = 0;
     let truncated = false;
     const truncatedContents: ExaContentResult[] = [];
 
-    for (const content of contents) {
-      const contentText = [
+    for (const content of contentResults) {
+      const segments = [
         content.title,
         content.summary,
         content.text,
-        ...(content.highlights || []),
-      ]
-        .filter(Boolean)
-        .join(' ');
+        content.highlights?.join(' '),
+      ].filter((segment): segment is string => Boolean(segment));
 
-      const contentLength = contentText.length;
+      const contentLength = segments.join(' ').length;
 
       if (totalCharacters + contentLength <= MAX_CHARACTERS) {
         truncatedContents.push(content);
@@ -220,7 +309,11 @@ export function formatExaResearchContext(contents: ExaContentResult[]): string {
     }
 
     if (content.highlights && content.highlights.length > 0) {
-      parts.push(`\n### Key Highlights\n${content.highlights.map(h => `- ${h}`).join('\n')}`);
+      parts.push(
+        `\n### Key Highlights\n${content.highlights
+          .map(highlight => `- ${highlight.trim()}`)
+          .join('\n')}`
+      );
     }
 
     if (content.text) {

--- a/services/polymarket.ts
+++ b/services/polymarket.ts
@@ -121,3 +121,15 @@ export async function fetchTopMarkets(limit: number = 10): Promise<PolymarketMar
 
   return markets as PolymarketMarket[];
 }
+
+/**
+ * Get Polymarket URL for a market
+ * Format: https://polymarket.com/event/{eventSlug}/{marketSlug}
+ */
+export function getPolymarketUrl(market: PolymarketMarket): string {
+  if (market.eventSlug) {
+    return `https://polymarket.com/event/${market.eventSlug}/${market.slug}`;
+  }
+  // Fallback to old format if eventSlug is not available
+  return `https://polymarket.com/event/${market.slug}`;
+}

--- a/services/prediction-publisher.ts
+++ b/services/prediction-publisher.ts
@@ -239,6 +239,11 @@ export async function publishExistingPrediction(dbPredictionId: string): Promise
     const prediction = data.prediction;
     const rawMarketData = data.rawMarket.data as PolymarketMarket;
 
+    // Add event slug to market data if available
+    if (data.eventSlug) {
+      rawMarketData.eventSlug = data.eventSlug;
+    }
+
     // Determine experiment ID from the prediction data or model
     // Try to extract from prediction data first
     let experimentId = 'unknown';

--- a/services/prediction-publisher.ts
+++ b/services/prediction-publisher.ts
@@ -1,0 +1,113 @@
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import { logger } from '../utils/logger.js';
+import { PolymarketMarket } from './polymarket.js';
+import { ExperimentRunResult } from './experiment-runner.js';
+
+const execAsync = promisify(exec);
+
+export interface GistPublishOptions {
+  predictionId: string;
+  experimentId: string;
+  experimentName: string;
+  market: PolymarketMarket;
+  result: ExperimentRunResult;
+}
+
+/**
+ * Format the prediction result as markdown for gist
+ */
+function formatPredictionMarkdown(options: GistPublishOptions): string {
+  const { predictionId, experimentId, experimentName, market, result } = options;
+
+  const markdown = `# Prediction Result: ${market.question}
+
+**Prediction ID:** ${predictionId}
+**Experiment:** [${experimentId}] ${experimentName}
+**Market:** [${market.question}](https://polymarket.com/event/${market.slug})
+**Market ID:** ${market.id}
+
+---
+
+## Market Details
+
+- **Question:** ${market.question}
+- **Description:** ${market.description || 'N/A'}
+- **End Date:** ${market.endDate || 'N/A'}
+- **Active:** ${market.active ? 'Yes' : 'No'}
+
+## Prediction Results
+
+\`\`\`json
+${JSON.stringify(result.data, null, 2)}
+\`\`\`
+
+## Experiment Configuration
+
+- **Experiment ID:** ${experimentId}
+- **Experiment Name:** ${experimentName}
+- **Success:** ${result.success ? 'Yes' : 'No'}
+${result.error ? `- **Error:** ${result.error}` : ''}
+
+---
+
+*Generated with [BetterAI Engine](https://github.com/better-labs/betteraiengine)*
+*Experiment: ${experimentId} | ${experimentName}*
+`;
+
+  return markdown;
+}
+
+/**
+ * Publish prediction results to a GitHub gist
+ */
+export async function publishPredictionGist(options: GistPublishOptions): Promise<string> {
+  const { predictionId } = options;
+  const filename = `prediction-${predictionId}.md`;
+
+  logger.info({ predictionId, filename }, 'Publishing prediction to GitHub gist');
+
+  try {
+    // Generate markdown content
+    const markdown = formatPredictionMarkdown(options);
+
+    // Write to temporary file
+    const fs = await import('fs/promises');
+    const tmpFile = `/tmp/${filename}`;
+    await fs.writeFile(tmpFile, markdown, 'utf-8');
+
+    // Create gist using gh CLI under better-labs organization
+    const { stdout, stderr } = await execAsync(
+      `gh gist create "${tmpFile}" --desc "Prediction ${predictionId} - ${options.market.question}" --public --org better-labs`
+    );
+
+    if (stderr && !stderr.includes('Creating gist')) {
+      logger.warn({ stderr }, 'gh gist create produced stderr output');
+    }
+
+    const gistUrl = stdout.trim();
+    logger.info({ predictionId, gistUrl }, 'Successfully published prediction to gist');
+
+    // Clean up temp file
+    await fs.unlink(tmpFile);
+
+    return gistUrl;
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    logger.error({ predictionId, error: errorMsg }, 'Failed to publish gist');
+    throw new Error(`Failed to publish gist: ${errorMsg}`);
+  }
+}
+
+/**
+ * Check if gh CLI is available
+ */
+export async function checkGhCliAvailable(): Promise<boolean> {
+  try {
+    await execAsync('gh --version');
+    return true;
+  } catch (error) {
+    logger.warn('gh CLI not available');
+    return false;
+  }
+}

--- a/services/prediction-publisher.ts
+++ b/services/prediction-publisher.ts
@@ -3,6 +3,8 @@ import { promisify } from 'util';
 import { logger } from '../utils/logger.js';
 import { PolymarketMarket } from './polymarket.js';
 import { ExperimentRunResult } from './experiment-runner.js';
+import { getPredictionById } from './prediction-storage.js';
+import { getExperimentMetadata } from '../experiments/config.js';
 
 const execAsync = promisify(exec);
 
@@ -76,9 +78,10 @@ export async function publishPredictionGist(options: GistPublishOptions): Promis
     const tmpFile = `/tmp/${filename}`;
     await fs.writeFile(tmpFile, markdown, 'utf-8');
 
-    // Create gist using gh CLI under better-labs organization
+    // Create gist using gh CLI
+    // Note: gh CLI doesn't support --org flag for gists, so this creates under the authenticated user
     const { stdout, stderr } = await execAsync(
-      `gh gist create "${tmpFile}" --desc "Prediction ${predictionId} - ${options.market.question}" --public --org better-labs`
+      `gh gist create "${tmpFile}" --desc "Prediction ${predictionId} - ${options.market.question}" --public`
     );
 
     if (stderr && !stderr.includes('Creating gist')) {
@@ -109,5 +112,86 @@ export async function checkGhCliAvailable(): Promise<boolean> {
   } catch (error) {
     logger.warn('gh CLI not available');
     return false;
+  }
+}
+
+/**
+ * Publish an existing prediction from database to GitHub gist
+ */
+export async function publishExistingPrediction(dbPredictionId: string): Promise<string> {
+  logger.info({ dbPredictionId }, 'Publishing existing prediction to gist');
+
+  try {
+    // Fetch prediction and market data from database
+    const data = await getPredictionById(dbPredictionId);
+
+    if (!data.prediction || !data.rawMarket) {
+      throw new Error('Prediction or market data not found in database');
+    }
+
+    // Extract data from database records
+    const prediction = data.prediction;
+    const rawMarketData = data.rawMarket.data as PolymarketMarket;
+
+    // Determine experiment ID from the prediction data or model
+    // Try to extract from prediction data first
+    let experimentId = 'unknown';
+    let experimentName = 'Unknown Experiment';
+
+    // Check if prediction data contains experiment info
+    if (prediction.prediction && typeof prediction.prediction === 'object') {
+      const predData = prediction.prediction as any;
+
+      // Try to infer experiment from model name
+      if (prediction.model) {
+        if (prediction.model.includes('gpt-4o')) {
+          experimentId = '001';
+        } else if (prediction.model.includes('claude-sonnet-4.5')) {
+          experimentId = '003';
+        } else if (prediction.model.includes('claude')) {
+          experimentId = '002';
+        }
+      }
+    }
+
+    // Get experiment metadata if we found an ID
+    if (experimentId !== 'unknown') {
+      const metadata = getExperimentMetadata(experimentId);
+      if (metadata) {
+        experimentName = metadata.name;
+      }
+    }
+
+    // Construct the result object to match ExperimentRunResult
+    const result: ExperimentRunResult = {
+      success: true,
+      experimentId,
+      experimentName,
+      marketId: prediction.marketId || rawMarketData.id,
+      data: {
+        marketId: prediction.marketId || rawMarketData.id,
+        prediction: prediction.prediction,
+        predictionDelta: prediction.predictionDelta,
+        model: prediction.model,
+      },
+    };
+
+    // Use the DB prediction ID for the gist filename
+    const gistPredictionId = dbPredictionId;
+
+    // Publish to gist using existing function
+    const gistUrl = await publishPredictionGist({
+      predictionId: gistPredictionId,
+      experimentId,
+      experimentName,
+      market: rawMarketData,
+      result,
+    });
+
+    return gistUrl;
+  } catch (error) {
+    const errorMsg = error instanceof Error ? error.message : String(error);
+    logger.error({ dbPredictionId, error: errorMsg }, 'Failed to publish existing prediction');
+    throw new Error(`Failed to publish existing prediction: ${errorMsg}`);
   }
 }

--- a/services/prediction-storage.ts
+++ b/services/prediction-storage.ts
@@ -94,7 +94,7 @@ export async function saveFailedPrediction(marketId: string, error: string) {
 }
 
 /**
- * Get a prediction by ID with associated market data
+ * Get a prediction by ID with associated market data and event data
  */
 export async function getPredictionById(predictionId: string) {
   try {
@@ -116,8 +116,22 @@ export async function getPredictionById(predictionId: string) {
       throw new Error(`Prediction ${predictionId} not found`);
     }
 
-    logger.info({ predictionId }, 'Successfully fetched prediction');
-    return result[0];
+    const data = result[0];
+
+    // Extract event slug from rawMarket data if available
+    let eventSlug: string | undefined;
+    if (data.rawMarket?.data) {
+      const marketData = data.rawMarket.data as any;
+      if (marketData.events && Array.isArray(marketData.events) && marketData.events.length > 0) {
+        eventSlug = marketData.events[0].slug;
+      }
+    }
+
+    logger.info({ predictionId, eventSlug }, 'Successfully fetched prediction');
+    return {
+      ...data,
+      eventSlug,
+    };
   } catch (error) {
     logger.error(
       { predictionId, error: error instanceof Error ? error.message : String(error) },

--- a/services/prediction-storage.ts
+++ b/services/prediction-storage.ts
@@ -4,6 +4,7 @@ import { logger } from '../utils/logger.js';
 
 export interface PredictionData {
   marketId: string;
+  experimentId: string;
   prediction: any;
   rawRequest?: any;
   rawResponse?: any;
@@ -37,6 +38,7 @@ export async function savePrediction(data: PredictionData) {
       .values({
         jobId: job[0].id,
         marketId: data.marketId,
+        experimentId: data.experimentId,
         prediction: data.prediction,
         rawRequest: data.rawRequest,
         rawResponse: data.rawResponse,


### PR DESCRIPTION
## Summary

This PR introduces significant enhancements to the BetterAI Engine prediction system:

- **Experiment Framework Extension**: Added Experiments 003 (separated reasoning fields) and 004 (Exa AI web research enrichment)
- **GitHub Publishing System**: New prediction publisher service that publishes prediction results to the `better-labs/prediction-history` repository via GitHub CLI
- **Database Schema Enhancement**: Added `experiment_id` field to predictions table for better tracking
- **CLI Enhancements**: Added `--publish-gist` flag to `run:experiment` and `run:batch` commands, plus new `publish:prediction` command for publishing existing predictions
- **Web Research Integration**: Integrated Exa AI API for real-time web research enrichment with source citations

### Key Features

1. **Separated Reasoning (Exp 003)**: Splits prediction reasoning into `outcomeReasoning` (why YES/NO/UNCERTAIN) and `confidenceReasoning` (why specific confidence level)

2. **Web Research Enrichment (Exp 004)**: Uses Exa AI Search + Contents APIs to gather relevant web sources and enrich prediction context with citations

3. **Automated Publishing**: Predictions can be automatically published to GitHub repository for transparency and tracking

## Test plan

- [x] Build project successfully
- [ ] Test Experiment 003 with separated reasoning
- [ ] Test Experiment 004 with Exa AI enrichment
- [ ] Test GitHub publishing with `--publish-gist` flag
- [ ] Test `publish:prediction` command with existing prediction ID
- [ ] Verify database migration for `experiment_id` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)